### PR TITLE
商品購入機能

### DIFF
--- a/app/assets/stylesheets/buyers/buyers.scss
+++ b/app/assets/stylesheets/buyers/buyers.scss
@@ -106,10 +106,10 @@
       }
       &__button{
         margin: 16px 0 0;
-        border: 1px solid #888;
-        background: #888;
+        border: 1px solid #ea352d;
+        background: #ea352d;
         color: #fff;
-        cursor: not-allowed;
+        cursor: pointer;
         display: block;
         width: 100%;
         line-height: 48px;

--- a/app/controllers/buyers_controller.rb
+++ b/app/controllers/buyers_controller.rb
@@ -1,4 +1,19 @@
 class BuyersController < ApplicationController
   def show
+    @product = Product.find(params[:id])
+    # 商品詳細完成次第解放
+    # @buyer = @user.find(session[:user_id])
+    #仮置きです↓
+    @buyer = User.find(21)
+    card = Credit.where(user_id: @buyer.id).first
+    Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+    customer = Payjp::Customer.retrieve(card.customer_id)
+    @default_card_information = customer.cards.retrieve(card.card_id)
+    session[:buyer_id] = @buyer.id
+    session[:price] = @product.price
+    session[:product_id] = @product.id
+  end
+
+  def index
   end
 end

--- a/app/controllers/credits_controller.rb
+++ b/app/controllers/credits_controller.rb
@@ -22,9 +22,11 @@ class CreditsController < ApplicationController
       redirect_to new_signup_pay_path
     else
       Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
-      @pay = Payjp::Charge.create(amount: 5000, customer: card.customer_id, currency: 'jpy')
+      @pay = Payjp::Charge.create(amount: session[:price], customer: card.customer_id, currency: 'jpy')
       if @pay
-        redirect_to root_path
+        @product = Product.find(session[:product_id])
+        @product.update(buyer_id: session[:buyer_id], status: 2)
+        redirect_to buyers_path
       else
         redirect_to buyer_path(@buyer), notice: '購入に失敗しました'
       end

--- a/app/views/buyers/index.html.haml
+++ b/app/views/buyers/index.html.haml
@@ -1,0 +1,16 @@
+.purchase
+  .purchase-icon
+    = image_tag 'mercari_logo_horizontal.png',class: 'purchase-icon-merukari'
+  .signup6
+    .signup6__main
+      .signup6__main__head
+        購入完了
+      .signup6__main__info
+        .signup6__main__info__thanks
+          ありがとうございます。
+        .signup6__main__info__thanks
+          購入が完了しました。
+        .signup6__main__info__btn
+          = link_to root_path, class: 'signup6__main__info__btn__start' do
+            商品一覧へ戻る
+= render 'buyers/buyer-footer'

--- a/app/views/buyers/show.html.haml
+++ b/app/views/buyers/show.html.haml
@@ -8,35 +8,35 @@
       %h2 購入を確定しますか？
     .purchase-page__item
       .purchase-page__item__imag
-        = image_tag "car.jpg"
+        = image_tag @product.images.first.image.url
       %h3.purchase-page__item__name
-        = link_to "ベルファイア"
+        = @product.name
       = form_with class: "purchase-page__item__price" do
         %p.purchase-page__item__price-money
-          = link_to "¥ 1,333,999"
+          = "¥" + @product.price.to_s
         %h3.purchase-page__item__price-tax
-          = link_to "送料込み" 
+          = @product.shipping_method
       %ul.purchase-page__item__point
         %li.purchase-page__item__point-list
           = link_to "ポイントはありません"
       %ul.purchase-page__item__payment
         %li.purchase-page__item__payment-text 
-          = link_to "支払い金額"
+          支払い金額
           %h3.purchase-page__item__payment-money
-            = link_to "¥ 1,300,000" 
-      %h3.purchase-page__item__attention 配送先と支払い方法の入力を完了してください。
+            = "¥" + @product.price.to_s
+      %h3.purchase-page__item__attention
       = form_tag(pay_path, method: :post) do
         %button.purchase-page__item__button 購入する
     %section.purchase-page__info
       .purchase-page__info__inner
         %h3 配送先
         %address.purchase-page__info__inner-address
-          〒333-9999 
+          = "〒" + @buyer.postal_cord.to_s
           %br/
           %br/
-          東京都/東京区 
+          = @buyer.city
           %br/
-          麻生/8888-12
+          = @buyer.address_number
         %p.purchase-page__info__inner-tax
           = link_to root_path, { class: "purchase-page__info-fix"} do
             %span 変更する

--- a/app/views/products/_item.html.haml
+++ b/app/views/products/_item.html.haml
@@ -2,7 +2,14 @@
   = link_to product_path(item.id) do
     %figure.item-box__photo
       -if item.images.present?
-        = image_tag item.images.first.image.url, class: "item-box__photo-lazyloaded"
+        -if item.buyer_id
+          = image_tag item.images.first.image.url, class: "item-box__photo-lazyloaded"
+          %figcaption.product-detail__others__section__item__box__href__figure__figcaption
+            .product-detail__others__section__item__box__href__figure__figcaption__sold-out
+              .product-detail__others__section__item__box__href__figure__figcaption__sold-out__budge 
+                SOLD
+        -else
+          = image_tag item.images.first.image.url, class: "item-box__photo-lazyloaded"
       -else
         = image_tag "noimage.png" ,class: "item-box__photo-lazyloaded"
     .item-box__body

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -88,7 +88,5 @@
           = render partial: "item", collection: @syupus 
       .view-all
         = link_to "すべての商品を見る"
-      = form_tag(pay_path, method: :post) do
-        %button.purchase-page__item__button 購入する
 = render 'botton'
 = render 'footer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root 'products#index'
   resources :products, only: [:index, :new, :create, :show]
-  resources :buyers, only: [:show]
+  resources :buyers, only: [:show, :index]
   resources :users, only: [:new]
   resource :login, to: 'users#login', only: :new
   resource :registration, controller: 'sessions', only: [:new, :create]


### PR DESCRIPTION
# WHAT
・ユーザーは商品を購入できる
・購入するとpayjpに履歴が残る
・購入が完了するとトップページの画像に「sold」がつく
# WHY
ユーザーが商品を購入できるようにするため

# TODO
soldになったら商品購入ページに遷移できないようにする