### PR TITLE
クレジット機能修正

### DIFF
--- a/app/assets/stylesheets/_flash.scss
+++ b/app/assets/stylesheets/_flash.scss
@@ -1,0 +1,4 @@
+.flash {
+  color: red;
+  font-size: 14px;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,6 +4,7 @@
 @import "mixin/clearfix";
 @import "mixin/user-form";
 @import "mixin/index-header";
+@import "flash";
 @import "modules/sell";
 @import "font-awesome";
 @import "header";

--- a/app/controllers/buyers_controller.rb
+++ b/app/controllers/buyers_controller.rb
@@ -4,11 +4,15 @@ class BuyersController < ApplicationController
     @buyer = User.find(session[:user_id])
     card = Credit.where(user_id: @buyer.id).first
     Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
-    customer = Payjp::Customer.retrieve(card.customer_id)
-    @default_card_information = customer.cards.retrieve(card.card_id)
-    session[:buyer_id] = @buyer.id
-    session[:price] = @product.price
-    session[:product_id] = @product.id
+    if card != nil
+      customer = Payjp::Customer.retrieve(card.customer_id)
+      @default_card_information = customer.cards.retrieve(card.card_id)
+      session[:buyer_id] = @buyer.id
+      session[:price] = @product.price
+      session[:product_id] = @product.id
+    else
+      redirect_to new_signup_pay_path, notice: 'クレジットカードを登録してください'
+    end
   end
 
   def index; end

--- a/app/views/sessions/signup_pay.html.haml
+++ b/app/views/sessions/signup_pay.html.haml
@@ -6,6 +6,9 @@
     = form_tag(credits_path, method: :post, class: "signup5__box__main",  name: "inputForm") do
       .signup5__box__main__form
         .signup5__box__main__form__group
+          .flash
+            - if flash[:notice]
+              = flash[:notice]
           %label.signup5__box__main__form__group__creditcard
             カード番号
           %span.signup5__box__main__form__group__span


### PR DESCRIPTION
# WHAT
クレジット登録ができていない場合購入しようとするとクレジット登録ページにリダイレクトしフラッシュが表示されるように修正しました。
なおフラッシュは.flashというクラスを使用すればすべてcolor:red;、font-size: 14px;になるよう設定したのでよければ使ってください。
![a7a2607fc8ab2316f57745b5171e5ac5](https://user-images.githubusercontent.com/48855821/57425421-0ea59f80-7256-11e9-8839-f9b83c313b08.gif)
