### PR TITLE
ユーザー登録バリデーション、フラッシュ機能追加

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,33 +10,62 @@ class SessionsController < ApplicationController
   def complete; end
 
   def create_user
-    # ロボット機能が本番環境で必要な為、コメントアウトにて対応しております。
-    if verify_recaptcha
-      @date = params["birthday(1i)"] + "-" + params["birthday(2i)"] + "-" + params["birthday(3i)"]
-      @birthday = @date.to_date
-      session[:nickname] = params[:nickname]
-      session[:email] = params[:email]
+    @date = params["birthday(1i)"] + "-" + params["birthday(2i)"] + "-" + params["birthday(3i)"]
+    @birthday = @date.to_date
+    session[:nickname] = params[:nickname]
+    session[:email] = params[:email]
+    session[:password] = params[:password]
+    session[:password_confirmation] = params[:password_confirmation]
+    session[:firstname_fullangle] = params[:firstname_fullangle]
+    session[:lastname_fullangle] = params[:lastname_fullangle]
+    session[:firstname_kana] = params[:firstname_kana]
+    session[:lastname_kana] = params[:lastname_kana]
+    session[:birthday] = @birthday
+    flash[:recaptcha] = '※押してください' if params["g-recaptcha-response"] == ""
+    flash[:nickname] = '※入力してください' if params[:nickname] == ""
+    flash[:nickname2] = 'すでに存在するユーザーです' if User.find_by(nickname: params[:nickname])
+    flash[:email] = '※入力してください' if params[:email] == ""
+    flash[:mail2] = 'すでに存在するメールアドレスです' if User.find_by(email: params[:email])
+    flash[:password] = '※入力してください' if params[:password] == ""
+    flash[:password_confirm] = '※入力してください' if params[:password_confirmation] == ""
+    flash[:password_match] = '※パスワードが一致しません' if params[:password] != params[:password_confirmation]
+    flash[:password_length] = '※6文字以上で入力してください' if params[:password].length <= 5
+    flash[:firstname_fullangle] = '※入力してください' if params[:firstname_fullangle] == ""
+    flash[:lastname_fullangle] = '※入力してください' if params[:lastname_fullangle] == ""
+    flash[:firstname_kana] = '※入力してください' if params[:firstname_kana] == ""
+    flash[:lastname_kana] = '※入力してください' if params[:lastname_kana] == ""
+    flash[:kana_first] = '※カタカナで記入してください' if params[:firstname_kana].match(/[\p{katakana}　ー－&&[^ -~｡-ﾟ]]+/) == nil
+    flash[:kana_last] = '※カタカナで記入してください' if params[:lastname_kana].match(/[\p{katakana}　ー－&&[^ -~｡-ﾟ]]+/) == nil
+    if params["g-recaptcha-response"] != "" && params[:nickname] != "" && params[:email] != "" && params[:password] != "" && params[:password_confirmation] != "" && params[:firstname_fullangle] != "" && params[:lastname_fullangle] != "" && params[:firstname_kana] != "" && params[:lastname_kana] != "" && User.find_by(nickname: params[:nickname]) == nil && User.find_by(email: params[:email]) == nil && params[:password] == params[:password_confirmation] && params[:password].length >= 5
       session[:password] = Rails.application.message_verifier('secret_key').generate(token: params[:password])
-      session[:password_confirmation] = params[:password_confirmation]
-      session[:firstname_fullangle] = params[:firstname_fullangle]
-      session[:lastname_fullangle] = params[:lastname_fullangle]
-      session[:firstname_kana] = params[:firstname_kana]
-      session[:lastname_kana] = params[:lastname_kana]
-      session[:birthday] = @birthday
+      redirect_to new_signup_phone_path
+    elsif params["g-recaptcha-response"] != "" && params[:nickname] != "" && params[:email] != "" && params[:password] != "" && params[:password_confirmation] != "" && params[:firstname_fullangle] != "" && params[:lastname_fullangle] != "" && params[:firstname_kana] != "" && params[:lastname_kana] != "" && User.find_by(nickname: params[:nickname]) == nil && User.find_by(email: params[:email]) == nil && session[:uid]
       redirect_to new_signup_phone_path
     else
-      redirect_to new_registration_path, notice: '※押してください'
+      redirect_to action: :new, controller: 'sessions'
     end
   end
 
   def create_address
+    session[:postal_cord] = params[:postal_cord]
+    session[:city] = params[:city]
+    session[:address_number] = params[:address_number]
+    flash[:firstname_fullangle] = '※入力してください' if params[:firstname_fullangle] == ""
+    flash[:lastname_fullangle] = '※入力してください' if params[:lastname_fullangle] == ""
+    flash[:firstname_kana] = '※入力してください' if params[:firstname_kana] == ""
+    flash[:lastname_kana] = '※入力してください' if params[:lastname_kana] == ""
+    flash[:kana_first] = '※カタカナで記入してください' if params[:firstname_kana].match(/[\p{katakana}　ー－&&[^ -~｡-ﾟ]]+/) == nil
+    flash[:kana_last] = '※カタカナで記入してください' if params[:lastname_kana].match(/[\p{katakana}　ー－&&[^ -~｡-ﾟ]]+/) == nil
+    flash[:postal_cord] = '※入力してください' if params[:postal_cord] == ""
+    flash[:city] = '※入力してください' if params[:city] == ""
+    flash[:address_number] = '※入力してください' if params[:address_number] == ""
     if session[:uid]
       @user = User.new(nickname: session[:nickname], email: session[:email], firstname_fullangle: session[:firstname_fullangle], lastname_fullangle: session[:lastname_fullangle], firstname_kana: session[:firstname_kana], lastname_kana: session[:lastname_kana], birthday: session[:birthday], postal_cord: params[:postal_cord], prefecture_id: params[:prefecture_id], city: params[:city], address_number: params[:address_number], building_name: params[:building_name], phone_number: params[:phone_number], uid: session[:uid], provider: session[:provider])
       if @user.save
         session[:user_id] = @user.id
         redirect_to new_signup_pay_path
       else
-        redirect_to new_user_path
+        redirect_to new_signup_address_path
       end
     else
       @user = User.new(nickname: session[:nickname], email: session[:email], firstname_fullangle: session[:firstname_fullangle], lastname_fullangle: session[:lastname_fullangle], firstname_kana: session[:firstname_kana], lastname_kana: session[:lastname_kana], birthday: session[:birthday], postal_cord: params[:postal_cord], prefecture_id: params[:prefecture_id], city: params[:city], address_number: params[:address_number], building_name: params[:building_name], phone_number: params[:phone_number], password: session[:password])
@@ -44,15 +73,15 @@ class SessionsController < ApplicationController
         session[:user_id] = @user.id
         redirect_to new_signup_pay_path
       else
-        redirect_to new_user_path
+        redirect_to new_signup_address_path
       end
     end
   end
 
   def login
     login_user = User.find_by(email: params[:email], password: Rails.application.message_verifier('secret_key').generate({ token: params[:password] }))
-      session[:user_id] = login_user.id if login_user
-      redirect_to root_path
+    session[:user_id] = login_user.id if login_user
+    redirect_to root_path
   end
 
   def logout

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,16 @@
 class UsersController < ApplicationController
   def new
+    session[:nickname] = nil
+    session[:email] = nil
+    session[:password] = nil
+    session[:password_confirmation] = nil
+    session[:firstname_fullangle] = nil
+    session[:lastname_fullangle] = nil
+    session[:firstname_kana] = nil
+    session[:lastname_kana] = nil
+    session[:postal_cord] = nil
+    session[:city] = nil
+    session[:address_number] = nil
   end
 
   def login

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -11,25 +11,55 @@
             ニックネーム
           %span.signup2-form-group__require.signup2-main__box__form__contents__nickname__require
             必須
-          = f.text_field :nickname, placeholder: '例) メルカリ太郎', class: 'signup2-form-group__form signup2-main__box__form__contents__nickname__form'
+          = f.text_field( :nickname, value: session[:nickname], placeholder: '例) メルカリ太郎', class: 'signup2-form-group__form signup2-main__box__form__contents__nickname__form')
+        .flash
+          - if flash[:nickname]
+            = flash[:nickname]
+        .flash
+          - if flash[:nickname2]
+            = flash[:nickname2]
         .signup2-form-group.signup2-main__box__form__contents__mail
           .signup2-form-group__name.signup2-main__box__form__contents__mail__text
             メールアドレス
           %span.signup2-form-group__require.signup2-main__box__form__contents__mail__require
             必須
-          = f.email_field :email, placeholder: 'PC・携帯どちらでも可', class: 'signup2-form-group__form signup2-main__box__form__contents__mail__form'
+          = f.email_field :email, value: session[:email], placeholder: 'PC・携帯どちらでも可', class: 'signup2-form-group__form signup2-main__box__form__contents__mail__form'
+        .flash
+          - if flash[:email]
+            = flash[:email]
+        .flash
+          - if flash[:email2]
+            = flash[:email2]
         .signup2-form-group.signup2-main__box__form__contents__password
           .signup2-form-group__name.signup2-main__box__form__contents__password__text
             パスワード
           %span.signup2-form-group__require.signup2-main__box__form__contents__password__require
             必須
-          = f.password_field :password, placeholder: '6文字以上', class: 'signup2-form-group__form signup2-main__box__form__contents__password__form'
+          = f.password_field :password, value: session[:password], placeholder: '6文字以上', class: 'signup2-form-group__form signup2-main__box__form__contents__password__form'
+        .flash
+          - if flash[:password]
+            = flash[:password]
+        .flash
+          - if flash[:password_match]
+            = flash[:password_match]
+        .flash
+          - if flash[:password_length]
+            = flash[:password_length]
         .signup2-form-group.signup2-main__box__form__contents__password-confirm
           .signup2-form-group__name.signup2-main__box__form__contents__password-confirm__text
             パスワード(確認)
           %span.signup2-form-group__require.signup2-main__box__form__contents__password-confirm__require
             必須
-          = f.password_field :password_confirmation, placeholder: '6文字以上', class: 'signup2-form-group__form signup2-main__box__form__contents__password-confirm__form'
+          = f.password_field :password_confirmation, value: session[:password_confirmation], placeholder: '6文字以上', class: 'signup2-form-group__form signup2-main__box__form__contents__password-confirm__form'
+        .flash
+          - if flash[:password_confirm]
+            = flash[:password_confirm]
+        .flash
+          - if flash[:password_match]
+            = flash[:password_match]
+        .flash
+          - if flash[:password_length]
+            = flash[:password_length]
         .signup2-form-group.signup2-main__box__form__contents__user-confirm
           .signup2-form-group.signup2-main__box__form__contents__user-confirm__head
             本人確認
@@ -40,25 +70,43 @@
             姓(全角)
           %span.signup2-form-group__require.signup2-main__box__form__contents__firstname__require
             必須
-          = f.text_field :firstname_fullangle, placeholder: '例) 山田', class: 'signup2-form-group__form signup2-main__box__form__contents__firstname__form'
+          = f.text_field :firstname_fullangle, value: session[:firstname_fullangle], placeholder: '例) 山田', class: 'signup2-form-group__form signup2-main__box__form__contents__firstname__form'
+        .flash
+          - if flash[:firstname_fullangle]
+            = flash[:firstname_fullangle]
         .signup2-form-group.signup2-main__box__form__contents__lastname
           .signup2-form-group__name.signup2-main__box__form__contents__lastname__text
             名(全角)
           %span.signup2-form-group__require.signup2-main__box__form__contents__lastname__require
             必須
-          = f.text_field :lastname_fullangle, placeholder: '例) 彩', class: 'signup2-form-group__form signup2-main__box__form__contents__lastname__form'
+          = f.text_field :lastname_fullangle, value: session[:lastname_fullangle], placeholder: '例) 彩', class: 'signup2-form-group__form signup2-main__box__form__contents__lastname__form'
+        .flash
+          - if flash[:lastname_fullangle]
+            = flash[:lastname_fullangle]
         .signup2-form-group.signup2-main__box__form__contents__first-kana
           .signup2-form-group__name.signup2-main__box__form__contents__first-kana__text
             姓カナ(全角)
           %span.signup2-form-group__require.signup2-main__box__form__contents__first-kana__require
             必須
-          = f.text_field :firstname_kana, placeholder: '例) ヤマダ', class: 'signup2-form-group__form signup2-main__box__form__contents__first-kana__form'
+          = f.text_field :firstname_kana, value: session[:firstname_kana], placeholder: '例) ヤマダ', class: 'signup2-form-group__form signup2-main__box__form__contents__first-kana__form'
+        .flash
+          - if flash[:firstname_kana]
+            = flash[:firstname_kana]
+        .flash
+          - if flash[:kana_first]
+            = flash[:kana_first]
         .signup2-form-group.signup2-main__box__form__contents__last-kana
           .signup2-form-group__name.signup2-main__box__form__contents__last-kana__text
             名カナ(全角)
           %span.signup2-form-group__require.signup2-main__box__form__contents__last-kana__require
             必須
-          = f.text_field :lastname_kana, placeholder: '例) アヤ', class: 'signup2-form-group__form signup2-main__box__form__contents__last-kana__form'
+          = f.text_field :lastname_kana, value: session[:lastname_kana], placeholder: '例) アヤ', class: 'signup2-form-group__form signup2-main__box__form__contents__last-kana__form'
+        .flash
+          - if flash[:lastname_kana]
+            = flash[:lastname_kana]
+        .flash
+          - if flash[:kana_last]
+            = flash[:kana_last]
         .signup2-form-group.signup2-main__box__form__contents__birth-day
           .signup2-form-group__name.signup2-main__box__form__contents__birth-day__text
             生年月日
@@ -73,11 +121,10 @@
             日
         .signup2-form-group.signup2-main__box__form__contents__info
           ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
-        -# ロボット機能が本番環境で必要な為、コメントアウトにて対応しております。
         = recaptcha_tags callback: 'recaptchaCallbackFunction'
         .flash
-          - if flash[:notice]
-            = flash[:notice]
+          - if flash[:recaptcha]
+            = flash[:recaptcha]
         .signup2-form-group.signup2-main__box__form__contents__agree-confirm
           .signup2-form-group.signup2-main__box__form__contents__agree-confirm__text
             「次へ進む」のボタンを押すことにより、利用規約に同意したものとみなします

--- a/app/views/sessions/signup_address.html.haml
+++ b/app/views/sessions/signup_address.html.haml
@@ -11,21 +11,42 @@
             名前(全角)
           %span.signup4-form-group__require.signup4-main__box__form__contents__name__require
             必須
-          = f.text_field :firstname_fullangle, placeholder: '例) 山田', class: 'signup4-form-group__form signup4-main__box__form__contents__name__form'
-          = f.text_field :lastname_fullangle, placeholder: '例) 彩', class: 'signup4-form-group__form signup4-main__box__form__contents__name__form'
+          = f.text_field :firstname_fullangle, value: session[:firstname_fullangle], placeholder: '例) 山田', class: 'signup4-form-group__form signup4-main__box__form__contents__name__form'
+        .flash
+          - if flash[:firstname_fullangle]
+            = flash[:firstname_fullangle]
+          = f.text_field :lastname_fullangle, value: session[:lastname_fullangle], placeholder: '例) 彩', class: 'signup4-form-group__form signup4-main__box__form__contents__name__form'
+        .flash
+          - if flash[:lastname_fullangle]
+            = flash[:lastname_fullangle]
         .signup4-form-group.signup4-main__box__form__contents__kana
           .signup4-form-group__name.signup4-main__box__form__contents__kana__text
             名前カナ(全角)
           %span.signup4-form-group__require.signup4-main__box__form__contents__kana__require
             必須
-          = f.text_field :firstname_kana, placeholder: '例) ヤマダ', class: 'signup4-form-group__form signup4-main__box__form__contents__kana__form'
-          = f.text_field :lastname_kana, placeholder: '例) アヤ', class: 'signup4-form-group__form signup4-main__box__form__contents__kana__form'
+          = f.text_field :firstname_kana, value: session[:firstname_kana], placeholder: '例) ヤマダ', class: 'signup4-form-group__form signup4-main__box__form__contents__kana__form'
+        .flash
+          - if flash[:firstname_kana]
+            = flash[:firstname_kana]
+        .flash
+          - if flash[:kana_first]
+            = flash[:kana_first]
+          = f.text_field :lastname_kana, value: session[:lastname_kana], placeholder: '例) アヤ', class: 'signup4-form-group__form signup4-main__box__form__contents__kana__form'
+        .flash
+          - if flash[:lastname_kana]
+            = flash[:lastname_kana]
+        .flash
+          - if flash[:kana_last]
+            = flash[:kana_last]
         .signup4-form-group.signup4-main__box__form__contents__postal-cord
           .signup4-form-group__name.signup4-main__box__form__contents__postal-cord__text
             郵便番号
           %span.signup4-form-group__require.signup4-main__box__form__contents__postal-cord__require
             必須
-          = f.number_field :postal_cord, placeholder: '例) 0000000', class: 'signup4-form-group__form signup4-main__box__form__contents__postal-cord__form'
+          = f.number_field :postal_cord, value: session[:postal_cord], placeholder: '例) 0000000', class: 'signup4-form-group__form signup4-main__box__form__contents__postal-cord__form'
+        .flash
+          - if flash[:postal_cord]
+            = flash[:postal_cord]
         .signup4-form-group.signup4-main__box__form__contents__prefecture
           .signup4-form-group__name.signup4-main__box__form__contents__prefecture__text
             都道府県
@@ -37,13 +58,19 @@
             市区町村
           %span.signup4-form-group__require.signup4-main__box__form__contents__city__require
             必須
-          = f.text_field :city, placeholder: '例) 横浜市緑区', class: 'signup4-form-group__form signup4-main__box__form__contents__city__form'
+          = f.text_field :city, value: session[:city], placeholder: '例) 横浜市緑区', class: 'signup4-form-group__form signup4-main__box__form__contents__city__form'
+        .flash
+          - if flash[:city]
+            = flash[:city]
         .signup4-form-group.signup4-main__box__form__contents__address-number
           .signup4-form-group__name.signup4-main__box__form__contents__address-number__text
             番地
           %span.signup4-form-group__require.signup4-main__box__form__contents__address-number__require
             必須
-          = f.text_field :address_number, placeholder: '例) 青山1-1-1', class: 'signup4-form-group__form signup4-main__box__form__contents__address-number__form'
+          = f.text_field :address_number, value: session[:address_number], placeholder: '例) 青山1-1-1', class: 'signup4-form-group__form signup4-main__box__form__contents__address-number__form'
+        .flash
+          - if flash[:address_number]
+            = flash[:address_number]
         .signup4-form-group.signup4-main__box__form__contents__building
           .signup4-form-group__name.signup4-main__box__form__contents__building__text
             建物名


### PR DESCRIPTION
# WHAT
・入力に不備があると不備のある部分にフラッシュが表示される
・不備があっても不備のない部分はそのまま残る
・届け先住所入力の時に最初のページで入力した名前が最初から入っている。
![cfe1915ad2f011d04f216b9dc527975f](https://user-images.githubusercontent.com/48855821/57510165-0bd3a900-7341-11e9-9e63-b7f546ed97e4.gif)
![d5e730ec9ecd94de729cf5d0cbd19f7e](https://user-images.githubusercontent.com/48855821/57510172-0d9d6c80-7341-11e9-8e7c-dcbdac2a34c9.gif)
![0b64dc7804df7185958cc5e8788304f5](https://user-images.githubusercontent.com/48855821/57510175-0ece9980-7341-11e9-90f1-8a094e87e316.gif)


