### PR TITLE
クレジット登録turbolinks導入

### DIFF
--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,5 +1,5 @@
-document.addEventListener(
-  "DOMContentLoaded", e => {
+document.addEventListener('turbolinks:load', e => {
+    console.log(document.getElementById("token_submit"));
     if (document.getElementById("token_submit") != null) {
       Payjp.setPublicKey("pk_test_186cecff486992e2a538cacb");
       let btn = document.getElementById("token_submit");


### PR DESCRIPTION
# WHAT
クレジットカード登録画面でリロードしなくても登録できるようにした。