### PR TITLE
商品詳細画面の発送元修正

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -32,4 +32,7 @@ class Product < ApplicationRecord
   scope :recent_brand, lambda { |count|
     where(brand_id: count).order(created_at: :DESC).limit(4)
   }
+
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :prefecture
 end

--- a/app/views/products/product-detail/_main.html.haml
+++ b/app/views/products/product-detail/_main.html.haml
@@ -84,7 +84,7 @@
             配送元地域
           %td.product-detail__item__main__table__tbody__tr__td
             = link_to root_path, class: 'product-detail__item__main__table__tbody__tr__td__place' do
-              = @product.prefecture_id
+              = @product.prefecture.name
         %tr.product-detail__item__main__table__tbody__tr
           %th.product-detail__item__main__table__tbody__tr__th
             発送日の目安


### PR DESCRIPTION
# WHAT
商品詳細画面の発送元地域にactivehashを適用させ、都道府県名を表示させるようにした。

# WHY
ユーザーが購入したい商品の発送元を確認できるようにするため。
![image](https://user-images.githubusercontent.com/48855821/57601895-aed23000-7598-11e9-94a5-6b27c1a2b06e.png)
